### PR TITLE
Document lighting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,15 @@ NoN ?= 1
 VERSION ?= 2.08J
 
 # Set to 1 to enable cel shading, algorithm by Sauraen and glank.
-# If your desired configuration is not in the list below, add it.
 CELSHADING ?= 0
 
 ARMIPS ?= armips
 
 OUTPUT_DIR ?= ./
 
-# List of all microcodes buildable with this codebase
+# List of all microcodes buildable with this codebase.
+# If your desired configuration is not in the list below, add it here, though
+# you won't get MD5sum checking.
 UCODES := F3DEX2_2.08 F3DEX2_2.07 F3DEX2_2.04H F3DEX2_2.08PL \
           F3DEX2_NoN_2.08 F3DEX2_NoN_2.07 F3DEX2_NoN_2.04H F3DEX2_NoN_2.08PL \
           F3DZEX_2.08J F3DZEX_2.08I F3DZEX_2.06H \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ NoN ?= 1
 #  2.08J (Animal Forest) (Recommended over 2.08I due to a change properly zeroes out $v0)
 #  2.08I (Majora's Mask)
 #  2.06H (Ocarina of Time)
-VERSION ?= 2.06H_celshading
+VERSION ?= 2.06H
+
+# Set to 1 to enable cel shading, algorithm by Sauraen and glank.
+# If your desired configuration is not in the list below, add it.
+CELSHADING ?= 1
 
 ARMIPS ?= armips
 
@@ -26,7 +30,7 @@ UCODES := F3DEX2_2.08 F3DEX2_2.07 F3DEX2_2.04H F3DEX2_2.08PL \
           F3DEX2_NoN_2.08 F3DEX2_NoN_2.07 F3DEX2_NoN_2.04H F3DEX2_NoN_2.08PL \
           F3DZEX_2.08J F3DZEX_2.08I F3DZEX_2.06H \
           F3DZEX_NoN_2.08J F3DZEX_NoN_2.08I F3DZEX_NoN_2.06H \
-          F3DZEX_NoN_2.06H_celshading
+          F3DZEX_NoN_cel_2.06H F3DZEX_NoN_cel_2.08J
 
 # F3DEX2
 MD5_CODE_F3DEX2_2.08      := 6ccf5fc392e440fb23bc7d7f7d71047c
@@ -46,8 +50,11 @@ MD5_CODE_F3DZEX_NoN_2.08I := ca0a31df36dbeda69f09e9850e68c7f7
 MD5_DATA_F3DZEX_NoN_2.08I := d31cea0e173c6a4a09e4dfe8f259c91b
 MD5_CODE_F3DZEX_NoN_2.06H := 96a1a7a8eab45e0882aab9e4d8ccbcc3
 MD5_DATA_F3DZEX_NoN_2.06H := e48c7679f1224b7c0947dcd5a4d0c713
-#MD5_CODE_F3DZEX_NoN_2.06H_celshading := da105ba384d036b69f7efa5bc3c14f1e
-#MD5_DATA_F3DZEX_NoN_2.06H_celshading := $(MD5_DATA_F3DZEX_NoN_2.06H)
+# Cel shading microcodes
+MD5_CODE_F3DZEX_NoN_cel_2.06H := da105ba384d036b69f7efa5bc3c14f1e
+MD5_DATA_F3DZEX_NoN_cel_2.06H := $(MD5_DATA_F3DZEX_NoN_2.06H)
+MD5_CODE_F3DZEX_NoN_cel_2.08J := 00000000000000000000000000000000
+MD5_DATA_F3DZEX_NoN_cel_2.08J := $(MD5_DATA_F3DZEX_NoN_2.08J)
 
 # Microcode strings
 # F3DEX2
@@ -68,7 +75,9 @@ NAME_F3DZEX_2.06H      := RSP Gfx ucode F3DZEX.NoN  fifo 2.06H Yoshitaka Yasumot
 NAME_F3DZEX_NoN_2.08J  := RSP Gfx ucode F3DZEX.NoN  fifo 2.08J Yoshitaka Yasumoto/Kawasedo 1999.
 NAME_F3DZEX_NoN_2.08I  := RSP Gfx ucode F3DZEX.NoN  fifo 2.08I Yoshitaka Yasumoto/Kawasedo 1999.
 NAME_F3DZEX_NoN_2.06H  := RSP Gfx ucode F3DZEX.NoN  fifo 2.06H Yoshitaka Yasumoto 1998 Nintendo.
-NAME_F3DZEX_NoN_2.06H_celshading := $(NAME_F3DZEX_NoN_2.06H)
+# Cel shading microcodes
+NAME_F3DZEX_NoN_cel_2.06H := $(NAME_F3DZEX_NoN_2.06H)
+NAME_F3DZEX_NoN_cel_2.08J := $(NAME_F3DZEX_NoN_2.08J)
 
 ID_F3DEX2_2.04H  := 0
 ID_F3DEX2_2.07   := 1
@@ -78,7 +87,6 @@ ID_F3DEX2_2.08PL := 3
 ID_F3DZEX_2.06H := 0
 ID_F3DZEX_2.08I := 1
 ID_F3DZEX_2.08J := 2
-ID_F3DZEX_2.06H_celshading := $(ID_F3DZEX_2.06H)
 
 TYPE_F3DEX2 := 0
 TYPE_F3DZEX := 1
@@ -99,9 +107,9 @@ WARNING := $(YELLOW)
 define set_vars
   FULL_UCODE := $(1)
   # These need to be eval'd to use their values in this same function
-  CUR_UCODE_WITHOUT_NON := $(subst _NoN,,$(1))
-  CUR_VERSION := $$(subst F3DZEX_,,$$(subst F3DEX2_,,$$(CUR_UCODE_WITHOUT_NON)))
-  CUR_UCODE := $$(patsubst %_$$(CUR_VERSION),%,$$(CUR_UCODE_WITHOUT_NON))
+  CUR_UCODE_NO_SUFFIX := $$(subst _cel,,$(subst _NoN,,$(1)))
+  CUR_VERSION := $$(subst F3DZEX_,,$$(subst F3DEX2_,,$$(CUR_UCODE_NO_SUFFIX)))
+  CUR_UCODE := $$(patsubst %_$$(CUR_VERSION),%,$$(CUR_UCODE_NO_SUFFIX))
   FULL_OUTPUT_DIR := $$(OUTPUT_DIR)/$(1)
 ifeq ($(OS),Windows_NT)
   FULL_OUTPUT_DIR := $$(subst /,\,$$(FULL_OUTPUT_DIR))
@@ -116,19 +124,17 @@ endif
   else
     CUR_NoN := 1
   endif
+  ifeq ($(findstring _cel,$(1)),)
+    CUR_celshading := 0
+  else
+    CUR_celshading := 1
+  endif
 
   NAME := $(NAME_$(1))
-  ID := $$(ID_$$(CUR_UCODE_WITHOUT_NON))
+  ID := $$(ID_$$(CUR_UCODE_NO_SUFFIX))
   TYPE := $$(TYPE_$$(CUR_UCODE))
   CODE_MD5 := $$(MD5_CODE_$(1))
   DATA_MD5 := $$(MD5_DATA_$(1))
-
-  ifeq ($(1),F3DZEX_NoN_2.06H_celshading)
-    CUR_celshading := 1
-  else
-    CUR_celshading := 0
-  endif
-
 endef
 
 # Sets up the microcode make rules
@@ -158,10 +164,12 @@ endif
   CODE_FILES += $(CODE_FILE)
 endef
 
+SUFFIX :=
 ifeq ($(NoN),1)
-  SUFFIX := _NoN
-else
-  SUFFIX := 
+  SUFFIX :=_NoN
+endif
+ifeq ($(CELSHADING),1)
+  SUFFIX :=$(SUFFIX)_cel
 endif
 INPUT_UCODE := $(UCODE)$(SUFFIX)_$(VERSION)
 FULL_OUTPUT_DIR := $(OUTPUT_DIR)/$(INPUT_UCODE)
@@ -170,6 +178,7 @@ ifeq ($(OS),Windows_NT)
 endif
 CODE_FILE := $(FULL_OUTPUT_DIR)/$(INPUT_UCODE).code
 DATA_FILE := $(FULL_OUTPUT_DIR)/$(INPUT_UCODE).data
+$(warning CODE_FILE $(CODE_FILE) DATA_FILE $(DATA_FILE))
 
 default: $(CODE_FILE) $(DATA_FILE)
 

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ NoN ?= 1
 #  2.08J (Animal Forest) (Recommended over 2.08I due to a change properly zeroes out $v0)
 #  2.08I (Majora's Mask)
 #  2.06H (Ocarina of Time)
-VERSION ?= 2.06H
+VERSION ?= 2.08J
 
 # Set to 1 to enable cel shading, algorithm by Sauraen and glank.
 # If your desired configuration is not in the list below, add it.
-CELSHADING ?= 1
+CELSHADING ?= 0
 
 ARMIPS ?= armips
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Selects the microcode to assemble. Options are F3DEX2 and F3DZEX
-UCODE ?= F3DZEX
+UCODE ?= F3DEX2
 
 # Set to 1 to enable NoN(No Nearclipping). Note that no official F3DZEX exists without NoN.
-NoN ?= 1
+NoN ?= 0
 
 # Selects which version of a given microcode to build:
 # F3DEX2:
@@ -15,23 +15,17 @@ NoN ?= 1
 #  2.08J (Animal Forest) (Recommended over 2.08I due to a change properly zeroes out $v0)
 #  2.08I (Majora's Mask)
 #  2.06H (Ocarina of Time)
-VERSION ?= 2.08J
-
-# Set to 1 to enable cel shading, algorithm by Sauraen and glank.
-CELSHADING ?= 0
+VERSION ?= 2.08
 
 ARMIPS ?= armips
 
 OUTPUT_DIR ?= ./
 
-# List of all microcodes buildable with this codebase.
-# If your desired configuration is not in the list below, add it here, though
-# you won't get MD5sum checking.
+# List of all microcodes buildable with this codebase
 UCODES := F3DEX2_2.08 F3DEX2_2.07 F3DEX2_2.04H F3DEX2_2.08PL \
           F3DEX2_NoN_2.08 F3DEX2_NoN_2.07 F3DEX2_NoN_2.04H F3DEX2_NoN_2.08PL \
           F3DZEX_2.08J F3DZEX_2.08I F3DZEX_2.06H \
-          F3DZEX_NoN_2.08J F3DZEX_NoN_2.08I F3DZEX_NoN_2.06H \
-          F3DZEX_NoN_cel_2.06H F3DZEX_NoN_cel_2.08J
+		      F3DZEX_NoN_2.08J F3DZEX_NoN_2.08I F3DZEX_NoN_2.06H
 
 # F3DEX2
 MD5_CODE_F3DEX2_2.08      := 6ccf5fc392e440fb23bc7d7f7d71047c
@@ -51,11 +45,6 @@ MD5_CODE_F3DZEX_NoN_2.08I := ca0a31df36dbeda69f09e9850e68c7f7
 MD5_DATA_F3DZEX_NoN_2.08I := d31cea0e173c6a4a09e4dfe8f259c91b
 MD5_CODE_F3DZEX_NoN_2.06H := 96a1a7a8eab45e0882aab9e4d8ccbcc3
 MD5_DATA_F3DZEX_NoN_2.06H := e48c7679f1224b7c0947dcd5a4d0c713
-# Cel shading microcodes
-MD5_CODE_F3DZEX_NoN_cel_2.06H := da105ba384d036b69f7efa5bc3c14f1e
-MD5_DATA_F3DZEX_NoN_cel_2.06H := $(MD5_DATA_F3DZEX_NoN_2.06H)
-MD5_CODE_F3DZEX_NoN_cel_2.08J := 00000000000000000000000000000000
-MD5_DATA_F3DZEX_NoN_cel_2.08J := $(MD5_DATA_F3DZEX_NoN_2.08J)
 
 # Microcode strings
 # F3DEX2
@@ -76,9 +65,6 @@ NAME_F3DZEX_2.06H      := RSP Gfx ucode F3DZEX.NoN  fifo 2.06H Yoshitaka Yasumot
 NAME_F3DZEX_NoN_2.08J  := RSP Gfx ucode F3DZEX.NoN  fifo 2.08J Yoshitaka Yasumoto/Kawasedo 1999.
 NAME_F3DZEX_NoN_2.08I  := RSP Gfx ucode F3DZEX.NoN  fifo 2.08I Yoshitaka Yasumoto/Kawasedo 1999.
 NAME_F3DZEX_NoN_2.06H  := RSP Gfx ucode F3DZEX.NoN  fifo 2.06H Yoshitaka Yasumoto 1998 Nintendo.
-# Cel shading microcodes
-NAME_F3DZEX_NoN_cel_2.06H := $(NAME_F3DZEX_NoN_2.06H)
-NAME_F3DZEX_NoN_cel_2.08J := $(NAME_F3DZEX_NoN_2.08J)
 
 ID_F3DEX2_2.04H  := 0
 ID_F3DEX2_2.07   := 1
@@ -108,9 +94,9 @@ WARNING := $(YELLOW)
 define set_vars
   FULL_UCODE := $(1)
   # These need to be eval'd to use their values in this same function
-  CUR_UCODE_NO_SUFFIX := $$(subst _cel,,$(subst _NoN,,$(1)))
-  CUR_VERSION := $$(subst F3DZEX_,,$$(subst F3DEX2_,,$$(CUR_UCODE_NO_SUFFIX)))
-  CUR_UCODE := $$(patsubst %_$$(CUR_VERSION),%,$$(CUR_UCODE_NO_SUFFIX))
+  CUR_UCODE_WITHOUT_NON := $(subst _NoN,,$(1))
+  CUR_VERSION := $$(subst F3DZEX_,,$$(subst F3DEX2_,,$$(CUR_UCODE_WITHOUT_NON)))
+  CUR_UCODE := $$(patsubst %_$$(CUR_VERSION),%,$$(CUR_UCODE_WITHOUT_NON))
   FULL_OUTPUT_DIR := $$(OUTPUT_DIR)/$(1)
 ifeq ($(OS),Windows_NT)
   FULL_OUTPUT_DIR := $$(subst /,\,$$(FULL_OUTPUT_DIR))
@@ -125,14 +111,9 @@ endif
   else
     CUR_NoN := 1
   endif
-  ifeq ($(findstring _cel,$(1)),)
-    CUR_celshading := 0
-  else
-    CUR_celshading := 1
-  endif
 
   NAME := $(NAME_$(1))
-  ID := $$(ID_$$(CUR_UCODE_NO_SUFFIX))
+  ID := $$(ID_$$(CUR_UCODE_WITHOUT_NON))
   TYPE := $$(TYPE_$$(CUR_UCODE))
   CODE_MD5 := $$(MD5_CODE_$(1))
   DATA_MD5 := $$(MD5_DATA_$(1))
@@ -144,7 +125,7 @@ define ucode_rule
 
   $(CODE_FILE) $(DATA_FILE) $(SYM_FILE) $(SYM2_FILE) $(TEMP_FILE): ./f3dex2.s ./rsp/* $(FULL_OUTPUT_DIR)
 	@printf "$(INFO)Building microcode: $(FULL_UCODE)$(NO_COL)\n"
-	$(ARMIPS) -strequ DATA_FILE $(DATA_FILE) -strequ CODE_FILE $(CODE_FILE) -strequ NAME "$(NAME)" -equ UCODE_TYPE $(TYPE) -equ UCODE_ID $(ID) -equ NoN $(CUR_NoN) -equ celshading $(CUR_celshading) f3dex2.s -sym2 $(SYM_FILE) -temp $(TEMP_FILE)
+	@$(ARMIPS) -strequ DATA_FILE $(DATA_FILE) -strequ CODE_FILE $(CODE_FILE) -strequ NAME "$(NAME)" -equ UCODE_TYPE $(TYPE) -equ UCODE_ID $(ID) -equ NoN $(CUR_NoN) f3dex2.s -sym2 $(SYM_FILE) -temp $(TEMP_FILE)
   ifeq ($(CODE_MD5),)
 	@printf "  $(WARNING)Nothing to compare $(1) to!$(NO_COL)\n"
   else
@@ -165,12 +146,10 @@ endif
   CODE_FILES += $(CODE_FILE)
 endef
 
-SUFFIX :=
 ifeq ($(NoN),1)
-  SUFFIX :=_NoN
-endif
-ifeq ($(CELSHADING),1)
-  SUFFIX :=$(SUFFIX)_cel
+  SUFFIX := _NoN
+else
+  SUFFIX := 
 endif
 INPUT_UCODE := $(UCODE)$(SUFFIX)_$(VERSION)
 FULL_OUTPUT_DIR := $(OUTPUT_DIR)/$(INPUT_UCODE)
@@ -179,7 +158,6 @@ ifeq ($(OS),Windows_NT)
 endif
 CODE_FILE := $(FULL_OUTPUT_DIR)/$(INPUT_UCODE).code
 DATA_FILE := $(FULL_OUTPUT_DIR)/$(INPUT_UCODE).data
-$(warning CODE_FILE $(CODE_FILE) DATA_FILE $(DATA_FILE))
 
 default: $(CODE_FILE) $(DATA_FILE)
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Selects the microcode to assemble. Options are F3DEX2 and F3DZEX
-UCODE ?= F3DEX2
+UCODE ?= F3DZEX
 
 # Set to 1 to enable NoN(No Nearclipping). Note that no official F3DZEX exists without NoN.
-NoN ?= 0
+NoN ?= 1
 
 # Selects which version of a given microcode to build:
 # F3DEX2:
@@ -15,7 +15,7 @@ NoN ?= 0
 #  2.08J (Animal Forest) (Recommended over 2.08I due to a change properly zeroes out $v0)
 #  2.08I (Majora's Mask)
 #  2.06H (Ocarina of Time)
-VERSION ?= 2.08
+VERSION ?= 2.06H
 
 ARMIPS ?= armips
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ NoN ?= 1
 #  2.08J (Animal Forest) (Recommended over 2.08I due to a change properly zeroes out $v0)
 #  2.08I (Majora's Mask)
 #  2.06H (Ocarina of Time)
-VERSION ?= 2.06H
+VERSION ?= 2.06H_celshading
 
 ARMIPS ?= armips
 
@@ -25,7 +25,8 @@ OUTPUT_DIR ?= ./
 UCODES := F3DEX2_2.08 F3DEX2_2.07 F3DEX2_2.04H F3DEX2_2.08PL \
           F3DEX2_NoN_2.08 F3DEX2_NoN_2.07 F3DEX2_NoN_2.04H F3DEX2_NoN_2.08PL \
           F3DZEX_2.08J F3DZEX_2.08I F3DZEX_2.06H \
-		      F3DZEX_NoN_2.08J F3DZEX_NoN_2.08I F3DZEX_NoN_2.06H
+          F3DZEX_NoN_2.08J F3DZEX_NoN_2.08I F3DZEX_NoN_2.06H \
+          F3DZEX_NoN_2.06H_celshading
 
 # F3DEX2
 MD5_CODE_F3DEX2_2.08      := 6ccf5fc392e440fb23bc7d7f7d71047c
@@ -45,6 +46,8 @@ MD5_CODE_F3DZEX_NoN_2.08I := ca0a31df36dbeda69f09e9850e68c7f7
 MD5_DATA_F3DZEX_NoN_2.08I := d31cea0e173c6a4a09e4dfe8f259c91b
 MD5_CODE_F3DZEX_NoN_2.06H := 96a1a7a8eab45e0882aab9e4d8ccbcc3
 MD5_DATA_F3DZEX_NoN_2.06H := e48c7679f1224b7c0947dcd5a4d0c713
+#MD5_CODE_F3DZEX_NoN_2.06H_celshading := da105ba384d036b69f7efa5bc3c14f1e
+#MD5_DATA_F3DZEX_NoN_2.06H_celshading := $(MD5_DATA_F3DZEX_NoN_2.06H)
 
 # Microcode strings
 # F3DEX2
@@ -65,6 +68,7 @@ NAME_F3DZEX_2.06H      := RSP Gfx ucode F3DZEX.NoN  fifo 2.06H Yoshitaka Yasumot
 NAME_F3DZEX_NoN_2.08J  := RSP Gfx ucode F3DZEX.NoN  fifo 2.08J Yoshitaka Yasumoto/Kawasedo 1999.
 NAME_F3DZEX_NoN_2.08I  := RSP Gfx ucode F3DZEX.NoN  fifo 2.08I Yoshitaka Yasumoto/Kawasedo 1999.
 NAME_F3DZEX_NoN_2.06H  := RSP Gfx ucode F3DZEX.NoN  fifo 2.06H Yoshitaka Yasumoto 1998 Nintendo.
+NAME_F3DZEX_NoN_2.06H_celshading := $(NAME_F3DZEX_NoN_2.06H)
 
 ID_F3DEX2_2.04H  := 0
 ID_F3DEX2_2.07   := 1
@@ -74,6 +78,7 @@ ID_F3DEX2_2.08PL := 3
 ID_F3DZEX_2.06H := 0
 ID_F3DZEX_2.08I := 1
 ID_F3DZEX_2.08J := 2
+ID_F3DZEX_2.06H_celshading := $(ID_F3DZEX_2.06H)
 
 TYPE_F3DEX2 := 0
 TYPE_F3DZEX := 1
@@ -117,6 +122,13 @@ endif
   TYPE := $$(TYPE_$$(CUR_UCODE))
   CODE_MD5 := $$(MD5_CODE_$(1))
   DATA_MD5 := $$(MD5_DATA_$(1))
+
+  ifeq ($(1),F3DZEX_NoN_2.06H_celshading)
+    CUR_celshading := 1
+  else
+    CUR_celshading := 0
+  endif
+
 endef
 
 # Sets up the microcode make rules
@@ -125,7 +137,7 @@ define ucode_rule
 
   $(CODE_FILE) $(DATA_FILE) $(SYM_FILE) $(SYM2_FILE) $(TEMP_FILE): ./f3dex2.s ./rsp/* $(FULL_OUTPUT_DIR)
 	@printf "$(INFO)Building microcode: $(FULL_UCODE)$(NO_COL)\n"
-	@$(ARMIPS) -strequ DATA_FILE $(DATA_FILE) -strequ CODE_FILE $(CODE_FILE) -strequ NAME "$(NAME)" -equ UCODE_TYPE $(TYPE) -equ UCODE_ID $(ID) -equ NoN $(CUR_NoN) f3dex2.s -sym2 $(SYM_FILE) -temp $(TEMP_FILE)
+	$(ARMIPS) -strequ DATA_FILE $(DATA_FILE) -strequ CODE_FILE $(CODE_FILE) -strequ NAME "$(NAME)" -equ UCODE_TYPE $(TYPE) -equ UCODE_ID $(ID) -equ NoN $(CUR_NoN) -equ celshading $(CUR_celshading) f3dex2.s -sym2 $(SYM_FILE) -temp $(TEMP_FILE)
   ifeq ($(CODE_MD5),)
 	@printf "  $(WARNING)Nothing to compare $(1) to!$(NO_COL)\n"
   else

--- a/f3dex2.s
+++ b/f3dex2.s
@@ -1972,75 +1972,95 @@ f3dzex_ovl2_0000168C:
     luv     $v29[0], 0x00B8($9)
 .endif
 f3dzex_ovl2_00001690:
-    vmulu   $v21, $v7, $v2[0h]
-    luv     $v4[0], 0x00A0($9)
-    vmacu   $v21, $v6, $v2[1h]
-    beq     $9, curClipRatio, f3dzex_ovl2_00001758
-     vmacu  $v21, $v5, $v2[2h]
-    vmulu   $v28, $v7, $v20[0h]
-    luv     $v3[0], 0x0088($9)
-    vmacu   $v28, $v6, $v20[1h]
-    addi    $11, $9, -0x18
-    vmacu   $v28, $v5, $v20[2h]
-    addi    $9, $9, -0x0030
-    vmrg    $v29, $v29, $v27
-    mtc2    $zero, $v4[6]
-    vmrg    $v3, $v3, $v0[0]
-    mtc2    $zero, $v4[14]
-    vand    $v21, $v21, $v31[7]
-    lpv     $v2[0], 0x00B0($9)
-    vand    $v28, $v28, $v31[7]
-    lpv     $v20[0], 0x0098($9)
-    vmulf   $v29, $v29, $v31[7]
-    vmacf   $v29, $v4, $v21[0h]
-    bne     $11, curClipRatio, f3dzex_ovl2_00001690
-     vmacf  $v29, $v3, $v28[0h]
-    vmrg    $v3, $v0, $v31[5]
-    llv     $v22[4], 0x0018(inputVtxPos)
-f3dzex_ovl2_000016F4:
-    vge     $v27, $v25, $v31[3] // v31[3] is 32512
-    andi    $11, $5, G_TEXTURE_GEN_H
-    vmulf   $v21, $v7, $v2[0h]
-    beqz    $11, f3dzex_00001870
-     suv    $v29[0], 0x0008(inputVtxPos)
-f3dzex_ovl2_00001708:
-    vmacf   $v21, $v6, $v2[1h]
-    andi    $12, $5, G_TEXTURE_GEN_LINEAR_H
-    vmacf   $v21, $v5, $v2[2h]
-    vxor    $v4, $v3, $v31[5]   // v31[5] is 0x4000
-    vmulf   $v28, $v7, $v20[0h]
-    vmacf   $v28, $v6, $v20[1h]
-    vmacf   $v28, $v5, $v20[2h]
-    lqv     $v2[0], (linearGenerateCoefficients)($zero)
-    vmudh   $v22, $v1, $v31[5]  // v31[5] is 16384
-    vmacf   $v22, $v3, $v21[0h]
-    beqz    $12, f3dzex_00001870
-     vmacf  $v22, $v4, $v28[0h]
-    vmadh   $v22, $v1, $v2[0]   // v2[0] is -0.5
-    vmulf   $v4, $v22, $v22
-    vmulf   $v3, $v22, $v31[7]  // v31[7] is 0.999969482421875
-    vmacf   $v3, $v22, $v2[2]   // v2[2] is 0.849212646484375
-.if (UCODE_IS_F3DEX2_204H)
-    vec3 equ v22
-.else
-    vec3 equ v21
-.endif
-    vmudh   $vec3, $v1, $v31[5]
-    vmacf   $v22, $v22, $v2[1]
-    j       f3dzex_00001870
-     vmacf  $v22, $v4, $v3
+LightLoop_12A0:
+/* 000012A0 0012A0 4A823D41 */  vmulu	$v21, $v7, $v2[0h]      /*normal 2n+1 X * vtx all*/
+/* 000012A4 0012A4 C9243814 */  luv		$v4[0], 0x88+0x18($9)   /*color light 2n+1*/
+/* 000012A8 0012A8 4AA23549 */  vmacu	$v21, $v6, $v2[1h]      /*normal 2n+1 Y * vtx Y only*/
+/* 000012AC 0012AC 112D002E */  beq		$9, $13, .L00001368     /*probably finish pipeline */
+/* 000012B0 0012B0 4AC22D49 */   vmacu	$v21, $v5, $v2[2h]      /*normal 2n+1 Z * vtx Z only*/
+/* 000012B4 0012B4 4A943F01 */  vmulu	$v28, $v7, $v20[0h]     /*normal 2n X * vtx all*/
+/* 000012B8 0012B8 C9233811 */  luv		$v3[0], 0x88($9)        /*color light 2n*/
+/* 000012BC 0012BC 4AB43709 */  vmacu	$v28, $v6, $v20[1h]     /*normal 2n Y * vtx Y only*/
+/* 000012C0 0012C0 212BFFE8 */  addi	$11, $9, -0x18
+/* 000012C4 0012C4 4AD42F09 */  vmacu	$v28, $v5, $v20[2h]     /*normal 2n Z * vtx Z only*/
+/* 000012C8 0012C8 2129FFD0 */  addi	$9, $9, -0x30
+/* These instructions were removed from the original to make space; no need to zero the alpha,
+it can be merged at the end. 4 instructions added below, a couple others tweaked I think */
+/* 0        0      4A1BEF67 */  /*vmrg	$v29, $v29, $v27*/      /*select orig alpha*/
+/* 0        0      48802300 */  /*mtc2	$zero, $v4[6]*/         /*alpha = 0, vtx 0, 2n+1*/
+/* 0        0      4B0018E7 */  /*vmrg	$v3, $v3, $v0[0]*/      /*alphas = 0, 2n*/
+/* 0        0      48802700 */  /*mtc2	$zero, $v4[14]*/        /*alpha = 0, vtx 1, 2n+1*/
+/* 000012CC 0012DC 4BFFAD68 */  vand	$v21, $v21, $v31[7]
+/* 000012D0 0012E0 C9223016 */  lpv		$v2[0], 0x98+0x18($9)   /*normal light 2n+1, (2) tgt B*/
+/* 000012D4 0012E4 4BFFE728 */  vand	$v28, $v28, $v31[7]
+/* 000012D8 0012E8 C9343013 */  lpv		$v20[0], 0x98($9)       /*normal light 2n, (2) tgt A, (1) tgt B*/
+/* 000012DC 0012EC 4BFFEF40 */  vmulf	$v29, $v29, $v31[7]
+/* 000012E0 0012F0 4A952748 */  vmacf	$v29, $v4, $v21[0h]     /*multiply add color 2n+1*/
+/* 000012E4 0012F4 156DFFEE */  bne		$11, $13, LightLoop_12A0
+/* 000012E8 0012F8 4A9C1F48 */   vmacf	$v29, $v3, $v28[0h]     /*multiply add color 2n*/
 
-f3dzex_ovl2_00001758:
-    vmrg    $v29, $v29, $v27
-    vmrg    $v4, $v4, $v0[0]
-    vand    $v21, $v21, $v31[7]
-    veq     $v3, $v31, $v31[3h]
-    lpv     $v2[0], 0x0080($9)
-    vmrg    $v3, $v0, $v31[5]
-    llv     $v22[4], 0x0018(inputVtxPos)
-    vmulf   $v29, $v29, $v31[7]
-    j       f3dzex_ovl2_000016F4
-     vmacf  $v29, $v4, $v21[0h]
+/* Modified from here */
+/* 000012EC 0012FC 4A1BEF67 */  vmrg    $v29, $v29, $v27        /*1 of 4 added: select orig alpha*/
+
+AfterSingleLight: /* rel 12F0, abs 1438 */
+/* 000012F0 001300 30AC0040 */  andi    $12, $5, 0x0040         /*2 of 4 added: is cel shading enabled?*/
+/* 000012F4 001304 4BBF00E7 */  vmrg	$v3, $v0, $v31[5]       /*pattern in color/alpha depending on VCC*/
+/* 000012F8 001308 11800002 */  beqz    $12, NoCelShading       /*3 of 4 added*/
+/* 000012FC 00130C C9D61206 */  llv		$v22[4], 0x18($14)
+/* Move green to all channels, including alpha; this is really what we wanted */
+/* 00001300 001310 4ABD0750 */  vadd    $v29, $v0, $v29[1h]     /*4 of 4 added */
+
+/* 010010 1 0101 11101 00000 11101 010000 */
+/* 01001010 10111101 00000111 01010000 */
+
+NoCelShading:
+/* Texgen */
+/* 00001304 001304 4B7FCEE3 */  vge		$v27, $v25, $v31[3]     /*some new setup of v27 or VCC*/
+/* 00001308 001308 30AB0004 */  andi	$11, $5, G_TEXTURE_GEN_H
+/* 0000130C 00130C 4A823D40 */  vmulf	$v21, $v7, $v2[0h]      /*tgt B X * vtx all*/
+/* 00001310 001310 11600061 */  beqz	$11, .L00001498
+/* 00001314 001314 E9DD3801 */   suv	$v29[0], 0x8($14)       /*write back color/alpha */
+
+func_00001318:
+/* Linear texgen*/
+/* 00001318 001318 4AA23548 */  vmacf	$v21, $v6, $v2[1h]      /*tgt B Y * vtx Y*/
+/* 0000131C 00131C 30AC0008 */  andi	$12, $5, G_TEXTURE_GEN_LINEAR_H
+/* 00001320 001320 4AC22D48 */  vmacf	$v21, $v5, $v2[2h]      /*tgt B Z * vtx Z*/
+/* 00001324 001324 4BBF192C */  vxor	$v4, $v3, $v31[5]       /*pattern in color, 0 in alpha*/
+/* 00001328 001328 4A943F00 */  vmulf	$v28, $v7, $v20[0h]     /*tgt A XYZ * vtx XYZ*/
+/* 0000132C 00132C 4AB43708 */  vmacf	$v28, $v6, $v20[1h]
+/* 00001330 001330 4AD42F08 */  vmacf	$v28, $v5, $v20[2h]
+/* 00001334 001334 C802201D */  lqv		$v2[0], 0x1D0($zero)
+/* 00001338 001338 4BBF0D87 */  vmudh	$v22, $v1, $v31[5]
+/* 0000133C 00133C 4A951D88 */  vmacf	$v22, $v3, $v21[0h]
+/* 00001340 001340 11800055 */  beqz	$12, .L00001498         /* abs 15E0, diff 148 */
+/* 00001344 001344 4A9C2588 */   vmacf	$v22, $v4, $v28[0h]
+
+func_00001348:
+/* 00001348 001348 4B020D8F */  vmadh	$v22, $v1, $v2[0]
+/* 0000134C 00134C 4A16B100 */  vmulf	$v4, $v22, $v22
+/* 00001350 001350 4BFFB0C0 */  vmulf	$v3, $v22, $v31[7]
+/* 00001354 001354 4B42B0C8 */  vmacf	$v3, $v22, $v2[2]
+/* 00001358 001358 4BBF0D47 */  vmudh	$v21, $v1, $v31[5]
+/* 0000135C 00135C 4B22B588 */  vmacf	$v22, $v22, $v2[1]
+/* 00001360 001360 08000578 */  j		func_000015E0
+/* 00001364 001364 4A032588 */   vmacf	$v22, $v4, $v3
+.L00001368:
+/* Lighting codepath if there is only one light (or an odd number), this was
+modified and shortened */
+/* 00001368 001368 4BFFAD68 */  vand	$v21, $v21, $v31[7]     /*mask dot product*/
+/* 0000136C 00136C 4BFFEF40 */  vmulf	$v29, $v29, $v31[7]     /*scale accum*/
+/* 00001370 001370 4A952748 */  vmacf	$v29, $v4, $v21[0h]     /*dot * color*/
+/* 00001374 001374 C9223010 */  lpv		$v2[0], 0x80($9)        /*load other tgt*/
+/* 00001378 001378 4A1BEF67 */  vmrg	$v29, $v29, $v27        /*select orig alpha*/
+/* 0000137C 00137C 0800050E */  j		AfterSingleLight        /* abs 1438 */
+/* 00001380 001380 4AFFF8E1 */  veq		$v3, $v31, $v31[3h]     /*00010001*/
+/*                 00000000 */  nop
+/*                 00000000 */  nop
+/*                 00000000 */  nop
+/* 0000136C 00136C 4B002127 */  /*vmrg	$v4, $v4, $v0[0]*/      /*zero alpha in color*/
+/* 00001380 001380 C9D61206 */  /*llv	$v22[4], 0x18($14)*/    /*after no cel shading*/
+/* 0000137C 00137C 4BBF00E7 */  /*vmrg	$v3, $v0, $v31[5]*/     /*mask only in color*/
 
 .align 8
 Overlay2End:

--- a/f3dex2.s
+++ b/f3dex2.s
@@ -1975,97 +1975,97 @@ f3dzex_ovl2_0000168C:
 .endif
 f3dzex_ovl2_00001690:
 LightLoop_12A0:
-/* 000012A0 0012A0 4A823D41 */  vmulu	$v21, $v7, $v2[0h]      /*normal 2n+1 X * vtx all*/
-/* 000012A4 0012A4 C9243814 */  luv		$v4[0], 0x88+0x18($9)   /*color light 2n+1*/
-/* 000012A8 0012A8 4AA23549 */  vmacu	$v21, $v6, $v2[1h]      /*normal 2n+1 Y * vtx Y only*/
-/* 000012AC 0012AC 112D002E */  beq		$9, $13, .L00001368     /*probably finish pipeline */
-/* 000012B0 0012B0 4AC22D49 */   vmacu	$v21, $v5, $v2[2h]      /*normal 2n+1 Z * vtx Z only*/
-/* 000012B4 0012B4 4A943F01 */  vmulu	$v28, $v7, $v20[0h]     /*normal 2n X * vtx all*/
-/* 000012B8 0012B8 C9233811 */  luv		$v3[0], 0x88($9)        /*color light 2n*/
-/* 000012BC 0012BC 4AB43709 */  vmacu	$v28, $v6, $v20[1h]     /*normal 2n Y * vtx Y only*/
-/* 000012C0 0012C0 212BFFE8 */  addi	$11, $9, -0x18
-/* 000012C4 0012C4 4AD42F09 */  vmacu	$v28, $v5, $v20[2h]     /*normal 2n Z * vtx Z only*/
-/* 000012C8 0012C8 2129FFD0 */  addi	$9, $9, -0x30
+    vmulu    $v21, $v7, $v2[0h]      /*normal 2n+1 X * vtx all*/
+    luv      $v4[0], 0x88+0x18($9)   /*color light 2n+1*/
+    vmacu    $v21, $v6, $v2[1h]      /*normal 2n+1 Y * vtx Y only*/
+    beq      $9, $13, .L00001368     /*probably finish pipeline */
+     vmacu    $v21, $v5, $v2[2h]     /*normal 2n+1 Z * vtx Z only*/
+    vmulu    $v28, $v7, $v20[0h]     /*normal 2n X * vtx all*/
+    luv      $v3[0], 0x88($9)        /*color light 2n*/
+    vmacu    $v28, $v6, $v20[1h]     /*normal 2n Y * vtx Y only*/
+    addi     $11, $9, -0x18
+    vmacu    $v28, $v5, $v20[2h]     /*normal 2n Z * vtx Z only*/
+    addi     $9, $9, -0x30
 /* These instructions were removed from the original to make space; no need to zero the alpha,
 it can be merged at the end. 4 instructions added below, a couple others tweaked I think */
-/* 0        0      4A1BEF67 */  /*vmrg	$v29, $v29, $v27*/      /*select orig alpha*/
-/* 0        0      48802300 */  /*mtc2	$zero, $v4[6]*/         /*alpha = 0, vtx 0, 2n+1*/
-/* 0        0      4B0018E7 */  /*vmrg	$v3, $v3, $v0[0]*/      /*alphas = 0, 2n*/
-/* 0        0      48802700 */  /*mtc2	$zero, $v4[14]*/        /*alpha = 0, vtx 1, 2n+1*/
-/* 000012CC 0012DC 4BFFAD68 */  vand	$v21, $v21, $v31[7]
-/* 000012D0 0012E0 C9223016 */  lpv		$v2[0], 0x98+0x18($9)   /*normal light 2n+1, (2) tgt B*/
-/* 000012D4 0012E4 4BFFE728 */  vand	$v28, $v28, $v31[7]
-/* 000012D8 0012E8 C9343013 */  lpv		$v20[0], 0x98($9)       /*normal light 2n, (2) tgt A, (1) tgt B*/
-/* 000012DC 0012EC 4BFFEF40 */  vmulf	$v29, $v29, $v31[7]
-/* 000012E0 0012F0 4A952748 */  vmacf	$v29, $v4, $v21[0h]     /*multiply add color 2n+1*/
-/* 000012E4 0012F4 156DFFEE */  bne		$11, $13, LightLoop_12A0
-/* 000012E8 0012F8 4A9C1F48 */   vmacf	$v29, $v3, $v28[0h]     /*multiply add color 2n*/
+    /*vmrg    $v29, $v29, $v27*/      /*select orig alpha*/
+    /*mtc2    $zero, $v4[6]*/         /*alpha = 0, vtx 0, 2n+1*/
+    /*vmrg    $v3, $v3, $v0[0]*/      /*alphas = 0, 2n*/
+    /*mtc2    $zero, $v4[14]*/        /*alpha = 0, vtx 1, 2n+1*/
+    vand     $v21, $v21, $v31[7]
+    lpv      $v2[0], 0x98+0x18($9)   /*normal light 2n+1, (2) tgt B*/
+    vand     $v28, $v28, $v31[7]
+    lpv      $v20[0], 0x98($9)       /*normal light 2n, (2) tgt A, (1) tgt B*/
+    vmulf    $v29, $v29, $v31[7]
+    vmacf    $v29, $v4, $v21[0h]     /*multiply add color 2n+1*/
+    bne      $11, $13, LightLoop_12A0
+     vmacf    $v29, $v3, $v28[0h]     /*multiply add color 2n*/
 
 /* Modified from here */
-/* 000012EC 0012FC 4A1BEF67 */  vmrg    $v29, $v29, $v27        /*1 of 4 added: select orig alpha*/
+    vmrg     $v29, $v29, $v27        /*1 of 4 added: select orig alpha*/
 
 f3dzex_ovl2_000016F4:
 AfterSingleLight: /* rel 12F0, abs 1438 */
-/* 000012F0 001300 30AC0040 */  andi    $12, $5, 0x0040         /*2 of 4 added: is cel shading enabled?*/
-/* 000012F4 001304 4BBF00E7 */  vmrg	$v3, $v0, $v31[5]       /*pattern in color/alpha depending on VCC*/
-/* 000012F8 001308 11800002 */  beqz    $12, NoCelShading       /*3 of 4 added*/
-/* 000012FC 00130C C9D61206 */  llv		$v22[4], 0x18($14)
+    andi    $12, $5, 0x0040         /*2 of 4 added: is cel shading enabled?*/
+    vmrg    $v3, $v0, $v31[5]       /*pattern in color/alpha depending on VCC*/
+    beqz    $12, NoCelShading       /*3 of 4 added*/
+    llv     $v22[4], 0x18($14)
 /* Move green to all channels, including alpha; this is really what we wanted */
-/* 00001300 001310 4ABD0750 */  vadd    $v29, $v0, $v29[1h]     /*4 of 4 added */
+    vadd    $v29, $v0, $v29[1h]     /*4 of 4 added */
 
 /* 010010 1 0101 11101 00000 11101 010000 */
 /* 01001010 10111101 00000111 01010000 */
 
 NoCelShading:
 /* Texgen */
-/* 00001304 001304 4B7FCEE3 */  vge		$v27, $v25, $v31[3]     /*some new setup of v27 or VCC*/
-/* 00001308 001308 30AB0004 */  andi	$11, $5, G_TEXTURE_GEN_H
-/* 0000130C 00130C 4A823D40 */  vmulf	$v21, $v7, $v2[0h]      /*tgt B X * vtx all*/
-/* 00001310 001310 11600061 */  beqz	$11, .L00001498
-/* 00001314 001314 E9DD3801 */   suv	$v29[0], 0x8($14)       /*write back color/alpha */
+    vge     $v27, $v25, $v31[3]     /*some new setup of v27 or VCC*/
+    andi    $11, $5, G_TEXTURE_GEN_H
+    vmulf   $v21, $v7, $v2[0h]      /*tgt B X * vtx all*/
+    beqz    $11, .L00001498
+     suv     $v29[0], 0x8($14)       /*write back color/alpha */
 
 f3dzex_ovl2_00001708:
 func_00001318:
 /* Linear texgen*/
-/* 00001318 001318 4AA23548 */  vmacf	$v21, $v6, $v2[1h]      /*tgt B Y * vtx Y*/
-/* 0000131C 00131C 30AC0008 */  andi	$12, $5, G_TEXTURE_GEN_LINEAR_H
-/* 00001320 001320 4AC22D48 */  vmacf	$v21, $v5, $v2[2h]      /*tgt B Z * vtx Z*/
-/* 00001324 001324 4BBF192C */  vxor	$v4, $v3, $v31[5]       /*pattern in color, 0 in alpha*/
-/* 00001328 001328 4A943F00 */  vmulf	$v28, $v7, $v20[0h]     /*tgt A XYZ * vtx XYZ*/
-/* 0000132C 00132C 4AB43708 */  vmacf	$v28, $v6, $v20[1h]
-/* 00001330 001330 4AD42F08 */  vmacf	$v28, $v5, $v20[2h]
-/* 00001334 001334 C802201D */  lqv		$v2[0], 0x1D0($zero)
-/* 00001338 001338 4BBF0D87 */  vmudh	$v22, $v1, $v31[5]
-/* 0000133C 00133C 4A951D88 */  vmacf	$v22, $v3, $v21[0h]
-/* 00001340 001340 11800055 */  beqz	$12, .L00001498         /* abs 15E0, diff 148 */
-/* 00001344 001344 4A9C2588 */   vmacf	$v22, $v4, $v28[0h]
+    vmacf   $v21, $v6, $v2[1h]      /*tgt B Y * vtx Y*/
+    andi    $12, $5, G_TEXTURE_GEN_LINEAR_H
+    vmacf   $v21, $v5, $v2[2h]      /*tgt B Z * vtx Z*/
+    vxor    $v4, $v3, $v31[5]       /*pattern in color, 0 in alpha*/
+    vmulf   $v28, $v7, $v20[0h]     /*tgt A XYZ * vtx XYZ*/
+    vmacf   $v28, $v6, $v20[1h]
+    vmacf   $v28, $v5, $v20[2h]
+    lqv     $v2[0], 0x1D0($zero)
+    vmudh   $v22, $v1, $v31[5]
+    vmacf   $v22, $v3, $v21[0h]
+    beqz    $12, .L00001498         /* abs 15E0, diff 148 */
+     vmacf   $v22, $v4, $v28[0h]
 
 func_00001348:
-/* 00001348 001348 4B020D8F */  vmadh	$v22, $v1, $v2[0]
-/* 0000134C 00134C 4A16B100 */  vmulf	$v4, $v22, $v22
-/* 00001350 001350 4BFFB0C0 */  vmulf	$v3, $v22, $v31[7]
-/* 00001354 001354 4B42B0C8 */  vmacf	$v3, $v22, $v2[2]
-/* 00001358 001358 4BBF0D47 */  vmudh	$v21, $v1, $v31[5]
-/* 0000135C 00135C 4B22B588 */  vmacf	$v22, $v22, $v2[1]
-/* 00001360 001360 08000578 */  j		func_000015E0
-/* 00001364 001364 4A032588 */   vmacf	$v22, $v4, $v3
+    vmadh   $v22, $v1, $v2[0]
+    vmulf   $v4, $v22, $v22
+    vmulf   $v3, $v22, $v31[7]
+    vmacf   $v3, $v22, $v2[2]
+    vmudh   $v21, $v1, $v31[5]
+    vmacf   $v22, $v22, $v2[1]
+    j       func_000015E0
+     vmacf   $v22, $v4, $v3
 f3dzex_ovl2_00001758:
 .L00001368:
 /* Lighting codepath if there is only one light (or an odd number), this was
 modified and shortened */
-/* 00001368 001368 4BFFAD68 */  vand	$v21, $v21, $v31[7]     /*mask dot product*/
-/* 0000136C 00136C 4BFFEF40 */  vmulf	$v29, $v29, $v31[7]     /*scale accum*/
-/* 00001370 001370 4A952748 */  vmacf	$v29, $v4, $v21[0h]     /*dot * color*/
-/* 00001374 001374 C9223010 */  lpv		$v2[0], 0x80($9)        /*load other tgt*/
-/* 00001378 001378 4A1BEF67 */  vmrg	$v29, $v29, $v27        /*select orig alpha*/
-/* 0000137C 00137C 0800050E */  j		AfterSingleLight        /* abs 1438 */
-/* 00001380 001380 4AFFF8E1 */  veq		$v3, $v31, $v31[3h]     /*00010001*/
-/*                 00000000 */  nop
-/*                 00000000 */  nop
-/*                 00000000 */  nop
-/* 0000136C 00136C 4B002127 */  /*vmrg	$v4, $v4, $v0[0]*/      /*zero alpha in color*/
-/* 00001380 001380 C9D61206 */  /*llv	$v22[4], 0x18($14)*/    /*after no cel shading*/
-/* 0000137C 00137C 4BBF00E7 */  /*vmrg	$v3, $v0, $v31[5]*/     /*mask only in color*/
+    vand    $v21, $v21, $v31[7]     /*mask dot product*/
+    vmulf   $v29, $v29, $v31[7]     /*scale accum*/
+    vmacf   $v29, $v4, $v21[0h]     /*dot * color*/
+    lpv     $v2[0], 0x80($9)        /*load other tgt*/
+    vmrg    $v29, $v29, $v27        /*select orig alpha*/
+    j       AfterSingleLight        /* abs 1438 */
+     veq     $v3, $v31, $v31[3h]     /*00010001*/
+    nop
+    nop
+    nop
+    /*vmrg  $v4, $v4, $v0[0]*/      /*zero alpha in color*/
+    /*llv   $v22[4], 0x18($14)*/    /*after no cel shading*/
+    /*vmrg  $v3, $v0, $v31[5]*/     /*mask only in color*/
 
 .align 8
 Overlay2End:

--- a/f3dex2.s
+++ b/f3dex2.s
@@ -924,6 +924,8 @@ f3dzex_0000182C:
     vge     $v27, $v25, $v31[3]
     llv     $v22[4], 0x0018(inputVtxPos)    // load the texture coords of the 2nd vertex into v22[4-7]
 f3dzex_00001870:
+.L00001498:
+func_000015E0:
 .if !(UCODE_IS_F3DEX2_204H) // Not in F3DEX2 2.04H
     vge     $v3, $v25, $v0[0]
 .endif

--- a/f3dex2.s
+++ b/f3dex2.s
@@ -2187,23 +2187,23 @@ lights_texgenpre:
 // Texgen beginning
     vge     $v27, $v25, $v31[3]         // INSTR 1: Finishing prev vtx store loop, some sort of clamp Z?
     andi    $11, $5, G_TEXTURE_GEN_H
-    vmulf   $v21, vPairNX, $v2[0h]      // Vertex normal X * last light dir X
+    vmulf   $v21, vPairNX, $v2[0h]      // Vertex normal X * lookat 0 dir X
     beqz    $11, vertices_store
      suv    ltColor[0], 0x0008(inputVtxPos) // write back color/alpha for two verts
 lights_texgenmain:
 // Texgen main
-    vmacf   $v21, vPairNY, $v2[1h]      // VN Y * last light dir Y
+    vmacf   $v21, vPairNY, $v2[1h]      // VN Y * lookat 0 dir Y
     andi    $12, $5, G_TEXTURE_GEN_LINEAR_H
-    vmacf   $v21, vPairNZ, $v2[2h]      // VN Z * last light dir Z
+    vmacf   $v21, vPairNZ, $v2[2h]      // VN Z * lookat 0 dir Z
     vxor    $v4, $v3, $v31[5]           // v4 is now 0x4000 in opposite pattern as v3, 00010001
-    vmulf   $v28, vPairNX, $v20[0h]     // VN XYZ * second to last light dir XYZ
+    vmulf   $v28, vPairNX, $v20[0h]     // VN XYZ * lookat 1 dir XYZ
     vmacf   $v28, vPairNY, $v20[1h]     // Y
     vmacf   $v28, vPairNZ, $v20[2h]     // Z
     lqv     $v2[0], (linearGenerateCoefficients)($zero)
     vmudh   vPairST, vOne, $v31[5]      // S, T init to 0x4000 each
-    vmacf   vPairST, $v3, $v21[0h]      // Add dot product with last light to S (only care about elems 2,3,6,7)
+    vmacf   vPairST, $v3, $v21[0h]      // Add dot product with lookat 0 to S (only care about elems 2,3,6,7)
     beqz    $12, vertices_store
-     vmacf  vPairST, $v4, $v28[0h]      // Add dot product with second to last light to T (elems 3, 7)
+     vmacf  vPairST, $v4, $v28[0h]      // Add dot product with lookat 1 to T (elems 3, 7)
 // Texgen Linear--not sure what formula this is implementing
     vmadh   vPairST, vOne, $v2[0]       // ST + Coefficient 0xC000
     vmulf   $v4, vPairST, vPairST       // ST squared

--- a/f3dex2.s
+++ b/f3dex2.s
@@ -1624,7 +1624,7 @@ Overlay0Address:
     jal     dma_read_write          // initiate DMA read
      li     $19, 0x0F48 - 1
     lw      $24, rdpHalf1Val
-    la      $20, 0x0180             // DMA address; equal to but probably not actuall spFxBase or clipRatio
+    la      $20, 0x0180             // DMA address; equal to but probably not actually spFxBase or clipRatio
     andi    $19, cmd_w0, 0x0FFF
     add     $24, $24, $20
     jal     dma_read_write          // initate DMA read

--- a/f3dex2.s
+++ b/f3dex2.s
@@ -2004,6 +2004,7 @@ it can be merged at the end. 4 instructions added below, a couple others tweaked
 /* Modified from here */
 /* 000012EC 0012FC 4A1BEF67 */  vmrg    $v29, $v29, $v27        /*1 of 4 added: select orig alpha*/
 
+f3dzex_ovl2_000016F4:
 AfterSingleLight: /* rel 12F0, abs 1438 */
 /* 000012F0 001300 30AC0040 */  andi    $12, $5, 0x0040         /*2 of 4 added: is cel shading enabled?*/
 /* 000012F4 001304 4BBF00E7 */  vmrg	$v3, $v0, $v31[5]       /*pattern in color/alpha depending on VCC*/
@@ -2023,6 +2024,7 @@ NoCelShading:
 /* 00001310 001310 11600061 */  beqz	$11, .L00001498
 /* 00001314 001314 E9DD3801 */   suv	$v29[0], 0x8($14)       /*write back color/alpha */
 
+f3dzex_ovl2_00001708:
 func_00001318:
 /* Linear texgen*/
 /* 00001318 001318 4AA23548 */  vmacf	$v21, $v6, $v2[1h]      /*tgt B Y * vtx Y*/
@@ -2047,6 +2049,7 @@ func_00001348:
 /* 0000135C 00135C 4B22B588 */  vmacf	$v22, $v22, $v2[1]
 /* 00001360 001360 08000578 */  j		func_000015E0
 /* 00001364 001364 4A032588 */   vmacf	$v22, $v4, $v3
+f3dzex_ovl2_00001758:
 .L00001368:
 /* Lighting codepath if there is only one light (or an odd number), this was
 modified and shortened */

--- a/f3dex2.s
+++ b/f3dex2.s
@@ -1973,6 +1973,82 @@ f3dzex_ovl2_0000168C:
 .else // No point lighting
     luv     $v29[0], 0x00B8($9)
 .endif
+
+.if celshading == 0
+
+f3dzex_ovl2_00001690:
+    vmulu   $v21, $v7, $v2[0h]
+    luv     $v4[0], 0x00A0($9)
+    vmacu   $v21, $v6, $v2[1h]
+    beq     $9, curClipRatio, f3dzex_ovl2_00001758
+     vmacu  $v21, $v5, $v2[2h]
+    vmulu   $v28, $v7, $v20[0h]
+    luv     $v3[0], 0x0088($9)
+    vmacu   $v28, $v6, $v20[1h]
+    addi    $11, $9, -0x18
+    vmacu   $v28, $v5, $v20[2h]
+    addi    $9, $9, -0x0030
+    vmrg    $v29, $v29, $v27
+    mtc2    $zero, $v4[6]
+    vmrg    $v3, $v3, $v0[0]
+    mtc2    $zero, $v4[14]
+    vand    $v21, $v21, $v31[7]
+    lpv     $v2[0], 0x00B0($9)
+    vand    $v28, $v28, $v31[7]
+    lpv     $v20[0], 0x0098($9)
+    vmulf   $v29, $v29, $v31[7]
+    vmacf   $v29, $v4, $v21[0h]
+    bne     $11, curClipRatio, f3dzex_ovl2_00001690
+     vmacf  $v29, $v3, $v28[0h]
+    vmrg    $v3, $v0, $v31[5]
+    llv     $v22[4], 0x0018(inputVtxPos)
+f3dzex_ovl2_000016F4:
+    vge     $v27, $v25, $v31[3] // v31[3] is 32512
+    andi    $11, $5, G_TEXTURE_GEN_H
+    vmulf   $v21, $v7, $v2[0h]
+    beqz    $11, f3dzex_00001870
+     suv    $v29[0], 0x0008(inputVtxPos)
+f3dzex_ovl2_00001708:
+    vmacf   $v21, $v6, $v2[1h]
+    andi    $12, $5, G_TEXTURE_GEN_LINEAR_H
+    vmacf   $v21, $v5, $v2[2h]
+    vxor    $v4, $v3, $v31[5]   // v31[5] is 0x4000
+    vmulf   $v28, $v7, $v20[0h]
+    vmacf   $v28, $v6, $v20[1h]
+    vmacf   $v28, $v5, $v20[2h]
+    lqv     $v2[0], (linearGenerateCoefficients)($zero)
+    vmudh   $v22, $v1, $v31[5]  // v31[5] is 16384
+    vmacf   $v22, $v3, $v21[0h]
+    beqz    $12, f3dzex_00001870
+     vmacf  $v22, $v4, $v28[0h]
+    vmadh   $v22, $v1, $v2[0]   // v2[0] is -0.5
+    vmulf   $v4, $v22, $v22
+    vmulf   $v3, $v22, $v31[7]  // v31[7] is 0.999969482421875
+    vmacf   $v3, $v22, $v2[2]   // v2[2] is 0.849212646484375
+.if (UCODE_IS_F3DEX2_204H)
+    vec3 equ v22
+.else
+    vec3 equ v21
+.endif
+    vmudh   $vec3, $v1, $v31[5]
+    vmacf   $v22, $v22, $v2[1]
+    j       f3dzex_00001870
+     vmacf  $v22, $v4, $v3
+
+f3dzex_ovl2_00001758:
+    vmrg    $v29, $v29, $v27
+    vmrg    $v4, $v4, $v0[0]
+    vand    $v21, $v21, $v31[7]
+    veq     $v3, $v31, $v31[3h]
+    lpv     $v2[0], 0x0080($9)
+    vmrg    $v3, $v0, $v31[5]
+    llv     $v22[4], 0x0018(inputVtxPos)
+    vmulf   $v29, $v29, $v31[7]
+    j       f3dzex_ovl2_000016F4
+     vmacf  $v29, $v4, $v21[0h]
+
+.else
+
 f3dzex_ovl2_00001690:
 LightLoop_12A0:
     vmulu    $v21, $v7, $v2[0h]      /*normal 2n+1 X * vtx all*/
@@ -2066,6 +2142,8 @@ modified and shortened */
     /*vmrg  $v4, $v4, $v0[0]*/      /*zero alpha in color*/
     /*llv   $v22[4], 0x18($14)*/    /*after no cel shading*/
     /*vmrg  $v3, $v0, $v31[5]*/     /*mask only in color*/
+
+.endif
 
 .align 8
 Overlay2End:

--- a/rsp/gbi.inc
+++ b/rsp/gbi.inc
@@ -13,7 +13,6 @@ OS_YIELD_DATA_SIZE equ 0xC00
 G_ZBUFFER               equ 0x00000001
 G_TEXTURE_ENABLE        equ 0x00000002
 G_SHADE                 equ 0x00000004
-G_LIGHTTOALPHA          equ 0x00000008 // Light intensity -> shade alpha (for cel shading)
 // In this byte, the whole byte is used as an index into a table, so using any
 // other bits will break forwards compatibility. Again, if you only want
 // backwards compatibility, AND 0x06 when this is loaded and then you can use
@@ -31,7 +30,9 @@ G_LIGHTING_POSITIONAL   equ 0x00400000
 G_CLIPPING              equ 0x00800000 // Initially on, but never checked
 // The top byte holds the geometry mode opcode in the clear mask, so all its
 // bits will either get cleared every time geom mode is set, or can never be
-// cleared.
+// cleared. The info in gbi.h warning programmers not to use the high 8 bits
+// because they form a "clip code mask" is kind of irrelevant given that these
+// bits can't be properly set or cleared.
 
 G_FOG_H                 equ G_FOG / 0x10000
 G_LIGHTING_H            equ G_LIGHTING / 0x10000

--- a/rsp/gbi.inc
+++ b/rsp/gbi.inc
@@ -115,3 +115,4 @@ G_MV_MATRIX   equ 0x0E
 
 inputVtxSize equ 0x10
 vtxSize equ 0x28
+lightSize equ 0x18

--- a/rsp/gbi.inc
+++ b/rsp/gbi.inc
@@ -3,9 +3,21 @@
 OS_YIELD_DATA_SIZE equ 0xC00
 
 // Geometry mode flags
+// First byte gets OR'd with 0xC8 to form triangle opcode. So we can use 0x80,
+// 0x40, and 0x08 for other purposes while remaining forward compatible. (Of
+// course, if you only care about backward compatibility, you can AND 0x07
+// before the OR 0xC8 and use all the extra bits.) Note that backward compatible
+// means a new/modded microcode will run old/vanilla DLs correctly, and forward
+// compatible means an old/vanilla microcode will run DLs made for a new/modded
+// microcode without any problems besides the specific new features missing.
 G_ZBUFFER               equ 0x00000001
 G_TEXTURE_ENABLE        equ 0x00000002
 G_SHADE                 equ 0x00000004
+G_LIGHTTOALPHA          equ 0x00000008 // Light intensity -> shade alpha (for cel shading)
+// In this byte, the whole byte is used as an index into a table, so using any
+// other bits will break forwards compatibility. Again, if you only want
+// backwards compatibility, AND 0x06 when this is loaded and then you can use
+// all six other bits.
 G_CULL_FRONT            equ 0x00000200
 G_CULL_BACK             equ 0x00000400
 G_CULL_BOTH             equ 0x00000600
@@ -13,10 +25,13 @@ G_FOG                   equ 0x00010000
 G_LIGHTING              equ 0x00020000
 G_TEXTURE_GEN           equ 0x00040000
 G_TEXTURE_GEN_LINEAR    equ 0x00080000
-G_LOD                   equ 0x00100000
+G_LOD                   equ 0x00100000 // Not used in any ucodes in repo
 G_SHADING_SMOOTH        equ 0x00200000
 G_LIGHTING_POSITIONAL   equ 0x00400000
-G_CLIPPING              equ 0x00800000
+G_CLIPPING              equ 0x00800000 // Initially on, but never checked
+// The top byte holds the geometry mode opcode in the clear mask, so all its
+// bits will either get cleared every time geom mode is set, or can never be
+// cleared.
 
 G_FOG_H                 equ G_FOG / 0x10000
 G_LIGHTING_H            equ G_LIGHTING / 0x10000


### PR DESCRIPTION
Comments and register names for lighting code and some vertex code. Not every line of code has a comment; things like matrix loads and matrix multiplies are documented as a whole (and register-named) to make the DMEM and register data organization clear.

The lighting data should now be shiftable in DMEM; there are no more "magic constants" in addresses in the lighting code, everything is based on symbols. This means DMEM might now be fully shiftable, though this has not been tested. `lightBufferMain` must come right after `lightBufferLookat` (they're really just one array), and all of this must come after spFxBase (possibly at least 0x30 after it if we don't want to trust that signed pointer arithmetic all works correctly, though it should).

Of course, this matches on all the microcodes which MD5s are provided for in the Makefile. 