### PR TITLE
Added errors for macros involving slt

### DIFF
--- a/f3dex2.s
+++ b/f3dex2.s
@@ -22,6 +22,24 @@
     ori dst, src, 0
 .endmacro
 
+// Prohibit macros involving slt; this silently clobbers $1. You can of course
+// manually write the slt and branch instructions if you want this behavior.
+.macro blt, ra, rb, lbl
+    .error "blt is a macro using slt, and silently clobbers $1!"
+.endmacro
+
+.macro bgt, ra, rb, lbl
+    .error "bgt is a macro using slt, and silently clobbers $1!"
+.endmacro
+
+.macro ble, ra, rb, lbl
+    .error "ble is a macro using slt, and silently clobbers $1!"
+.endmacro
+
+.macro bge, ra, rb, lbl
+    .error "bge is a macro using slt, and silently clobbers $1!"
+.endmacro
+
 // Vector macros
 .macro vcopy, dst, src
     vadd dst, src, $v0[0]


### PR DESCRIPTION
The "instructions" `blt`, `bgt`, `ble`, and `bge` are actually macros like `slt $1, ra, rb; bne $1, $0, label`. This silently clobbers the value of `$1`, which is not the assembler temporary register in RSP asm like it is in MIPS. This burned me while modding.

This PR adds macro definitions which make these macros throw errors. These instructions/macros are not used in any vanilla microcodes. If a user really wants their behavior, they can write the `slt` / branch instructions manually (typically using a different register as the temporary).